### PR TITLE
Fix navigation links for GitHub Pages base path deployment

### DIFF
--- a/web-app/src/routes/+layout.svelte
+++ b/web-app/src/routes/+layout.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import '../app.css';
 	import { page } from '$app/state';
+	import { base } from '$app/paths';
 
 	let { children } = $props();
 
@@ -13,11 +14,25 @@
 		{ href: '/settings', label: 'Settings', icon: 'M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z M15 12a3 3 0 11-6 0 3 3 0 016 0z' }
 	];
 
-	function isActive(href: string): boolean {
-		if (href === '/') {
-			return page.url.pathname === '/';
+	// Get the pathname without the base prefix for comparison
+	function getRelativePath(pathname: string): string {
+		if (base && pathname.startsWith(base)) {
+			return pathname.slice(base.length) || '/';
 		}
-		return page.url.pathname.startsWith(href);
+		return pathname;
+	}
+
+	function isActive(href: string): boolean {
+		const relativePath = getRelativePath(page.url.pathname);
+		if (href === '/') {
+			return relativePath === '/';
+		}
+		return relativePath.startsWith(href);
+	}
+
+	// Construct full href with base path
+	function fullHref(href: string): string {
+		return href === '/' ? base || '/' : base + href;
 	}
 </script>
 
@@ -47,7 +62,7 @@
 				{#each navItems as item}
 					<li>
 						<a
-							href={item.href}
+							href={fullHref(item.href)}
 							class="flex items-center gap-3 px-3 py-2 rounded-lg transition-colors {isActive(item.href) ? 'bg-blue-50 text-blue-700' : 'text-gray-700 hover:bg-gray-100'}"
 							aria-current={isActive(item.href) ? 'page' : undefined}
 						>

--- a/web-app/svelte.config.js
+++ b/web-app/svelte.config.js
@@ -9,7 +9,6 @@ const config = {
 
 	kit: {
 		adapter: adapter({
-			// GitHub Pages serves from a subdirectory based on repo name
 			// Set fallback for SPA routing
 			fallback: '404.html'
 		}),

--- a/web-app/tests/e2e/layout.spec.ts
+++ b/web-app/tests/e2e/layout.spec.ts
@@ -1,6 +1,34 @@
 import { test, expect } from '@playwright/test';
 
 test.describe('App Layout', () => {
+	test.describe('base path navigation', () => {
+		// These tests verify that navigation links work correctly with SvelteKit's base path.
+		// In dev mode, base is empty. In production, base is '/ai-translator'.
+		// The fix ensures links use {base} prefix so they work in both environments.
+
+		test('navigation links have href attributes that match their destinations', async ({ page }) => {
+			await page.goto('/');
+
+			// Get all navigation links and verify their hrefs
+			const navLinks = [
+				{ name: /upload/i, expectedPath: '/' },
+				{ name: /convert pdf/i, expectedPath: '/convert' },
+				{ name: /cleanup/i, expectedPath: '/cleanup' },
+				{ name: /translate/i, expectedPath: '/translate' },
+				{ name: /my documents/i, expectedPath: '/documents' },
+				{ name: /settings/i, expectedPath: '/settings' }
+			];
+
+			for (const { name, expectedPath } of navLinks) {
+				const link = page.getByRole('link', { name });
+				const href = await link.getAttribute('href');
+				// href should end with the expected path (base prefix may vary)
+				expect(href).toMatch(new RegExp(`${expectedPath}$`));
+			}
+		});
+
+	});
+
 	test('displays the header with app title', async ({ page }) => {
 		await page.goto('/');
 


### PR DESCRIPTION
## Summary

- Use SvelteKit's `base` path from `$app/paths` to construct navigation hrefs
- Ensures links work correctly whether deployed at root or in a subdirectory like `/ai-translator/`
- Fixes issue where navigation tabs like `/settings` weren't working on GitHub Pages

## Changes

- Import `base` from `$app/paths` in layout component
- Add `fullHref()` function to prefix links with base path
- Update `isActive()` to compare paths without base prefix
- Add e2e test for navigation link href validation

## Test plan

- [x] All 67 e2e tests pass
- [x] Production build verified to contain correct base path prefixes
- [ ] Deploy to GitHub Pages and verify navigation works

🤖 Generated with [Claude Code](https://claude.com/claude-code)