### PR TITLE
Add payment method guidance to API key help page

### DIFF
--- a/PLAN-custom-target-language.md
+++ b/PLAN-custom-target-language.md
@@ -1,0 +1,342 @@
+# Custom Target Language Feature - Implementation Plan
+
+## Overview
+
+Add a configurable target language input that allows users to specify the translation language with optional style modifiers (e.g., "Japanese", "business casual German", "intimate, warm French"). This replaces the hardcoded Japanese-only translation.
+
+## Current Architecture Analysis
+
+### CLI Components
+- `src/cli.js`: Parses CLI arguments, currently no language option
+- `src/translator.js`: Already supports `targetLanguage` parameter (defaults to 'Japanese')
+- `src/translationEngine.js`: Orchestrates translation, passes chunks to translator
+- `src/index.js`: Entry point, currently hardcoded output filenames like `-japanese.md`
+- `src/assembler.js`: Creates output files with hardcoded `-japanese` naming
+
+### Web App Components
+- `web-app/src/routes/translate/+page.svelte`: Translation UI, no language input
+- `web-app/src/lib/services/translator.ts`: Already supports `targetLanguage` parameter (defaults to 'Japanese')
+- `web-app/src/lib/services/translationEngine.ts`: Passes chunks to translator
+- `web-app/src/lib/storage.ts`: IndexedDB storage for documents
+
+### Key Observations
+1. **The translator already supports custom target language** - both CLI and web app have the parameter plumbed through
+2. **Output filenames are hardcoded** - `-japanese.md` needs to become dynamic
+3. **No history mechanism exists** - need to create localStorage-based history
+4. **Validation is needed** - the language input is required but needs helpful prompting
+
+---
+
+## Feature Requirements
+
+### 1. Required Language Input
+- Text input field for specifying target language/style
+- Field is required - cannot start translation without it
+- Validation message explains what to enter (e.g., "Enter a language like 'Japanese' or a style like 'formal German'")
+
+### 2. History Dropdown
+- Store history of previous language entries (max 10 items)
+- Show as dropdown/autocomplete above the input
+- Most recent entries first
+- Persist across sessions (localStorage for web, config file for CLI)
+
+### 3. Dynamic Output Naming
+- Output files named based on language code or short name
+- Examples: `book-de.md` for German, `book-fr.md` for French
+- For complex styles: extract language code or use first word
+
+### 4. AI-Verified Testing
+- Use gpt-5-nano to verify output is in expected language
+- Tests for at least 3 languages: German, French, Spanish
+
+---
+
+## Interface Designs
+
+### CLI Interface
+
+```bash
+# New required flag: --target-language or --to
+node src/index.js book.md --to "Japanese"
+node src/index.js book.md --to "business casual German"
+node src/index.js book.md --to "intimate, warm French"
+
+# Short form
+node src/index.js book.md -t "Spanish"
+
+# Error when missing
+$ node src/index.js book.md
+Error: Target language is required. Use --to <language> to specify.
+Examples:
+  --to "Japanese"
+  --to "formal German"
+  --to "conversational Spanish"
+```
+
+### Web App Interface
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ Translate Document                                       │
+├─────────────────────────────────────────────────────────┤
+│                                                         │
+│ Select document to translate:                           │
+│ ┌─────────────────────────────────────────────────────┐ │
+│ │ test-book.md                              ▼         │ │
+│ └─────────────────────────────────────────────────────┘ │
+│                                                         │
+│ Target Language: *                                      │
+│ ┌─────────────────────────────────────────────────────┐ │
+│ │ Japanese                                      ▼     │ │
+│ └─────────────────────────────────────────────────────┘ │
+│ ┌─────────────────────────────────────────────────────┐ │
+│ │ Recent:                                             │ │
+│ │ • Japanese                                          │ │
+│ │ • business casual German                            │ │
+│ │ • formal French                                     │ │
+│ └─────────────────────────────────────────────────────┘ │
+│                                                         │
+│ Enter a language name (e.g., "Japanese") or style      │
+│ (e.g., "business casual German")                       │
+│                                                         │
+│ [Model: gpt-5-mini ▼]  [Chunk Size: 4000]             │
+│                                                         │
+│ [ Start Translation ]                                   │
+└─────────────────────────────────────────────────────────┘
+```
+
+**Validation State (when empty):**
+```
+Target Language: *
+┌─────────────────────────────────────────────────────────┐
+│                                              (empty)    │
+└─────────────────────────────────────────────────────────┘
+⚠️ Required: Enter a target language (e.g., "Japanese",
+   "formal German", or "conversational Spanish")
+```
+
+---
+
+## Implementation Plan (TDD Approach)
+
+### Phase 1: CLI - Target Language Parameter
+
+#### Step 1.1: CLI Argument Parsing
+**Test first:** `test/cli.test.js`
+```javascript
+test('should parse --to flag for target language', () => {
+  const args = ['node', 'index.js', 'test.md', '--to', 'German'];
+  const result = parseCliArgs(args);
+  expect(result.targetLanguage).toBe('German');
+});
+
+test('should throw error when --to is missing', () => {
+  const args = ['node', 'index.js', 'test.md'];
+  expect(() => parseCliArgs(args)).toThrow(/target language is required/i);
+});
+
+test('should accept -t as short form', () => {
+  const args = ['node', 'index.js', 'test.md', '-t', 'French'];
+  const result = parseCliArgs(args);
+  expect(result.targetLanguage).toBe('French');
+});
+```
+
+**Implementation:** Update `src/cli.js` to:
+- Add `--to` / `-t` flag parsing
+- Make it required for translation mode (not rectify/pdf-to-md)
+- Provide helpful error message
+
+#### Step 1.2: Pass Language Through Pipeline
+**Test first:** Integration test
+```javascript
+test('should pass target language to translator', () => {
+  // Mock translator and verify targetLanguage is passed
+});
+```
+
+**Implementation:** Update `src/index.js` to pass `options.targetLanguage` to translator
+
+#### Step 1.3: Dynamic Output Naming
+**Test first:** `test/assembler.test.js`
+```javascript
+test('should generate language code from target language', () => {
+  expect(getLanguageCode('German')).toBe('de');
+  expect(getLanguageCode('business casual German')).toBe('de');
+  expect(getLanguageCode('French')).toBe('fr');
+  expect(getLanguageCode('Unknown Language')).toBe('translated');
+});
+
+test('should name output file with language code', () => {
+  // Test assembleTranslation with language parameter
+});
+```
+
+**Implementation:**
+- Add `getLanguageCode()` helper function
+- Update assembler functions to accept language parameter
+- Update `src/index.js` to use dynamic naming
+
+### Phase 2: Web App - Target Language Input
+
+#### Step 2.1: Language Input Component
+**Test first:** `web-app/tests/unit/LanguageInput.test.ts`
+```typescript
+it('should render input field for target language');
+it('should show validation error when empty');
+it('should hide validation error when filled');
+it('should show history dropdown when available');
+```
+
+#### Step 2.2: Language History Storage
+**Test first:** `web-app/tests/unit/languageHistory.test.ts`
+```typescript
+it('should store language to history');
+it('should limit history to 10 items');
+it('should put most recent at top');
+it('should persist to localStorage');
+it('should load history from localStorage');
+```
+
+**Implementation:** Create `web-app/src/lib/languageHistory.ts`
+
+#### Step 2.3: Translate Page Integration
+**Test first:** `web-app/tests/e2e/translate.spec.ts`
+```typescript
+test('translate button is disabled when language is empty');
+test('shows validation message when language is empty');
+test('enables translate when language is filled');
+test('stores language to history after successful translation');
+test('shows language history dropdown');
+```
+
+**Implementation:** Update `web-app/src/routes/translate/+page.svelte`
+
+#### Step 2.4: Dynamic Document Naming
+**Test first:**
+```typescript
+test('names output document with language code');
+test('stores translated document with correct name');
+```
+
+### Phase 3: AI Language Verification Tests
+
+#### Step 3.1: Create Language Verification Helper
+**File:** `test/helpers/languageVerifier.js`
+```javascript
+async function verifyLanguage(text, expectedLanguage) {
+  // Use gpt-5-nano to verify
+  const response = await openai.chat.completions.create({
+    model: 'gpt-5-nano',
+    messages: [{
+      role: 'user',
+      content: `Is the following text written in ${expectedLanguage}? Answer only "yes" or "no".\n\n${text}`
+    }]
+  });
+  return response.choices[0].message.content.toLowerCase().includes('yes');
+}
+```
+
+#### Step 3.2: Multi-Language Integration Tests
+**File:** `test/integration/multiLanguage.test.js`
+```javascript
+describe('Multi-language translation', () => {
+  test('translates to German', async () => {
+    const result = await translateChunk('Hello world', {}, 'German');
+    const isGerman = await verifyLanguage(result, 'German');
+    expect(isGerman).toBe(true);
+  });
+
+  test('translates to French', async () => {
+    const result = await translateChunk('Hello world', {}, 'French');
+    const isFrench = await verifyLanguage(result, 'French');
+    expect(isFrench).toBe(true);
+  });
+
+  test('translates to Spanish', async () => {
+    const result = await translateChunk('Hello world', {}, 'Spanish');
+    const isSpanish = await verifyLanguage(result, 'Spanish');
+    expect(isSpanish).toBe(true);
+  });
+});
+```
+
+---
+
+## Language Code Mapping
+
+Common language codes for output file naming:
+
+| Language | Code |
+|----------|------|
+| Japanese | ja |
+| German | de |
+| French | fr |
+| Spanish | es |
+| Italian | it |
+| Portuguese | pt |
+| Chinese | zh |
+| Korean | ko |
+| Russian | ru |
+| Arabic | ar |
+| Dutch | nl |
+| Swedish | sv |
+
+For unrecognized languages or complex style descriptions, extract the first recognized language or use "translated" as fallback.
+
+---
+
+## File Changes Summary
+
+### CLI (root project)
+
+| File | Changes |
+|------|---------|
+| `src/cli.js` | Add `--to`/`-t` flag, make required for translation |
+| `src/index.js` | Pass targetLanguage to translator, dynamic output naming |
+| `src/assembler.js` | Add getLanguageCode(), update assembleJapaneseOnly to assembleTranslation |
+| `test/cli.test.js` | Tests for --to flag |
+| `test/assembler.test.js` | Tests for language code extraction |
+| `test/integration/multiLanguage.test.js` | New: AI-verified language tests |
+| `test/helpers/languageVerifier.js` | New: Helper for AI language verification |
+
+### Web App
+
+| File | Changes |
+|------|---------|
+| `web-app/src/lib/languageHistory.ts` | New: History management |
+| `web-app/src/lib/components/LanguageInput.svelte` | New: Input with history dropdown |
+| `web-app/src/routes/translate/+page.svelte` | Add language input, validation, history |
+| `web-app/tests/unit/languageHistory.test.ts` | New: History tests |
+| `web-app/tests/unit/LanguageInput.test.ts` | New: Component tests |
+| `web-app/tests/e2e/translate.spec.ts` | Add language input tests |
+
+---
+
+## Execution Order
+
+1. **Phase 1.1**: CLI argument parsing (RED → GREEN)
+2. **Phase 1.2**: Pipeline integration (RED → GREEN)
+3. **Phase 1.3**: Dynamic output naming (RED → GREEN)
+4. **Phase 2.1**: Language history module (RED → GREEN)
+5. **Phase 2.2**: LanguageInput component (RED → GREEN)
+6. **Phase 2.3**: Translate page integration (RED → GREEN)
+7. **Phase 2.4**: Web app document naming (RED → GREEN)
+8. **Phase 3**: AI verification tests (RED → GREEN)
+
+Each phase follows strict TDD:
+1. Write failing test
+2. Run test to confirm failure
+3. Write minimal implementation
+4. Run test to confirm pass
+5. Refactor if needed
+6. Move to next test
+
+---
+
+## Backwards Compatibility
+
+- Existing translations will continue to work
+- `--to "Japanese"` produces same output as before
+- Web app will default to empty (no default language) to force explicit choice
+- Existing documents in IndexedDB unchanged (variant field remains)

--- a/src/assembler.js
+++ b/src/assembler.js
@@ -1,6 +1,64 @@
 import { writeFileSync, mkdirSync } from 'fs';
 import { dirname, basename, join } from 'path';
 
+// Language code mapping for common languages
+const LANGUAGE_CODES = {
+  japanese: 'ja',
+  german: 'de',
+  french: 'fr',
+  spanish: 'es',
+  italian: 'it',
+  portuguese: 'pt',
+  chinese: 'zh',
+  korean: 'ko',
+  russian: 'ru',
+  arabic: 'ar',
+  dutch: 'nl',
+  swedish: 'sv',
+  norwegian: 'no',
+  danish: 'da',
+  finnish: 'fi',
+  polish: 'pl',
+  turkish: 'tr',
+  hindi: 'hi',
+  thai: 'th',
+  vietnamese: 'vi',
+  indonesian: 'id',
+  greek: 'el',
+  hebrew: 'he',
+  czech: 'cs',
+  hungarian: 'hu',
+  ukrainian: 'uk'
+};
+
+/**
+ * Extracts language code from a target language string.
+ * Handles both simple language names ("Japanese") and style-qualified descriptions
+ * ("business casual German", "formal French").
+ * Returns "translated" for unknown languages.
+ */
+export function getLanguageCode(targetLanguage) {
+  if (!targetLanguage) {
+    return 'translated';
+  }
+
+  const lowerTarget = targetLanguage.toLowerCase();
+
+  // First, check for exact matches
+  if (LANGUAGE_CODES[lowerTarget]) {
+    return LANGUAGE_CODES[lowerTarget];
+  }
+
+  // Look for a known language name anywhere in the string
+  for (const [language, code] of Object.entries(LANGUAGE_CODES)) {
+    if (lowerTarget.includes(language)) {
+      return code;
+    }
+  }
+
+  return 'translated';
+}
+
 export function assembleJapaneseOnly(chunks, outputPath) {
   const translatedContent = chunks
     .map(chunk => chunk.translation)

--- a/src/cli.js
+++ b/src/cli.js
@@ -9,6 +9,7 @@ export function parseCliArgs(args) {
   let rectify = false;
   let pdfToMd = false;
   let contextAware = true;
+  let targetLanguage = undefined;
 
   for (let i = 0; i < cliArgs.length; i++) {
     const arg = cliArgs[i];
@@ -27,7 +28,9 @@ export function parseCliArgs(args) {
       pdfToMd = true;
     } else if (arg === '--no-context') {
       contextAware = false;
-    } else if (!arg.startsWith('--')) {
+    } else if (arg === '--to' || arg === '-t') {
+      targetLanguage = cliArgs[++i];
+    } else if (!arg.startsWith('--') && !arg.startsWith('-')) {
       inputFile = arg;
     }
   }
@@ -40,7 +43,19 @@ export function parseCliArgs(args) {
     throw new Error('Cannot use --rectify and --pdf-to-md flags together');
   }
 
-  return {
+  // Require target language for translation mode (not rectify or pdf-to-md)
+  const isTranslationMode = !rectify && !pdfToMd;
+  if (isTranslationMode && !targetLanguage) {
+    throw new Error(
+      'Target language is required. Use --to <language> to specify.\n' +
+      'Examples:\n' +
+      '  --to "Japanese"\n' +
+      '  --to "formal German"\n' +
+      '  --to "conversational Spanish"'
+    );
+  }
+
+  const result = {
     inputFile,
     outputDir,
     chunkSize,
@@ -50,4 +65,10 @@ export function parseCliArgs(args) {
     pdfToMd,
     contextAware
   };
+
+  if (targetLanguage) {
+    result.targetLanguage = targetLanguage;
+  }
+
+  return result;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,7 @@ import { createRectifier } from './rectifier.js';
 import { createPdfConverter } from './pdfConverter.js';
 import { translateDocument } from './translationEngine.js';
 import { rectifyDocument } from './rectificationEngine.js';
-import { assembleJapaneseOnly, assembleBilingual, assembleRectified, assemblePdfToMarkdown } from './assembler.js';
+import { assembleJapaneseOnly, assembleBilingual, assembleRectified, assemblePdfToMarkdown, getLanguageCode } from './assembler.js';
 import { join, basename, extname } from 'path';
 
 async function main() {
@@ -91,6 +91,7 @@ async function main() {
       console.log('Translation Configuration:');
       console.log(`  Input file: ${options.inputFile}`);
       console.log(`  Output directory: ${options.outputDir}`);
+      console.log(`  Target language: ${options.targetLanguage}`);
       console.log(`  Chunk size: ${options.chunkSize}`);
       console.log(`  Model: ${options.model}`);
       console.log(`  Reasoning effort: ${options.reasoningEffort}`);
@@ -110,7 +111,8 @@ async function main() {
       const translator = createTranslator({
         model: options.model,
         reasoningEffort: options.reasoningEffort,
-        contextAware: options.contextAware
+        contextAware: options.contextAware,
+        targetLanguage: options.targetLanguage
       });
 
       console.log('Starting translation...');
@@ -136,12 +138,13 @@ async function main() {
       }));
 
       const fileBaseName = basename(options.inputFile, extname(options.inputFile));
-      const japaneseOutputPath = join(options.outputDir, `${fileBaseName}-japanese.md`);
+      const languageCode = getLanguageCode(options.targetLanguage);
+      const translatedOutputPath = join(options.outputDir, `${fileBaseName}-${languageCode}.md`);
       const bilingualOutputPath = join(options.outputDir, `${fileBaseName}-bilingual.md`);
 
-      console.log('Assembling Japanese-only output...');
-      assembleJapaneseOnly(transformedChunks, japaneseOutputPath);
-      console.log(`  Saved: ${japaneseOutputPath}`);
+      console.log(`Assembling ${options.targetLanguage} output...`);
+      assembleJapaneseOnly(transformedChunks, translatedOutputPath);
+      console.log(`  Saved: ${translatedOutputPath}`);
 
       console.log('Assembling bilingual output...');
       assembleBilingual(transformedChunks, bilingualOutputPath);

--- a/src/translator.js
+++ b/src/translator.js
@@ -33,6 +33,7 @@ export function createTranslator(options = {}) {
   const model = options.model || 'gpt-4o';
   const verbosity = options.verbosity || 'low';
   const contextAware = options.contextAware !== false; // Default to true
+  const defaultTargetLanguage = options.targetLanguage || 'Japanese';
 
   // Helper to check if model is GPT-5.1 family (supports "none", not "minimal")
   function isGpt51Model(modelName) {
@@ -182,10 +183,11 @@ CRITICAL: Complete Translation Required:
     }
   };
 
-  async function translateChunk(chunk, contextOrLanguage = {}, targetLanguage = 'Japanese') {
+  async function translateChunk(chunk, contextOrLanguage = {}, targetLanguage = null) {
     // Handle backward compatibility: second argument can be context object or target language string
     let context = {};
-    let language = targetLanguage;
+    // Use the language passed as argument, or fall back to the default configured at creation
+    let language = targetLanguage || defaultTargetLanguage;
 
     if (typeof contextOrLanguage === 'string') {
       // Legacy call: translateChunk(chunk, 'Spanish')

--- a/test/assembler.test.js
+++ b/test/assembler.test.js
@@ -2,7 +2,7 @@ import { describe, test, expect, beforeEach, afterEach } from '@jest/globals';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
 import { readFileSync, existsSync, mkdirSync, rmSync } from 'fs';
-import { assembleJapaneseOnly, assembleBilingual, assembleRectified, assemblePdfToMarkdown } from '../src/assembler.js';
+import { assembleJapaneseOnly, assembleBilingual, assembleRectified, assemblePdfToMarkdown, getLanguageCode } from '../src/assembler.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -354,6 +354,45 @@ describe('assembler', () => {
 
       expect(existsSync(outputPath)).toBe(true);
       expect(existsSync(nestedOutputDir)).toBe(true);
+    });
+  });
+
+  describe('getLanguageCode', () => {
+    test('should return language code for common languages', () => {
+      expect(getLanguageCode('Japanese')).toBe('ja');
+      expect(getLanguageCode('German')).toBe('de');
+      expect(getLanguageCode('French')).toBe('fr');
+      expect(getLanguageCode('Spanish')).toBe('es');
+      expect(getLanguageCode('Italian')).toBe('it');
+      expect(getLanguageCode('Portuguese')).toBe('pt');
+      expect(getLanguageCode('Chinese')).toBe('zh');
+      expect(getLanguageCode('Korean')).toBe('ko');
+      expect(getLanguageCode('Russian')).toBe('ru');
+      expect(getLanguageCode('Dutch')).toBe('nl');
+    });
+
+    test('should extract language from style-qualified descriptions', () => {
+      expect(getLanguageCode('business casual German')).toBe('de');
+      expect(getLanguageCode('formal French')).toBe('fr');
+      expect(getLanguageCode('conversational Spanish')).toBe('es');
+      expect(getLanguageCode('intimate, warm Japanese')).toBe('ja');
+    });
+
+    test('should be case insensitive', () => {
+      expect(getLanguageCode('japanese')).toBe('ja');
+      expect(getLanguageCode('GERMAN')).toBe('de');
+      expect(getLanguageCode('FrEnCh')).toBe('fr');
+    });
+
+    test('should return "translated" for unknown languages', () => {
+      expect(getLanguageCode('Klingon')).toBe('translated');
+      expect(getLanguageCode('Unknown Language')).toBe('translated');
+    });
+
+    test('should handle empty or undefined input', () => {
+      expect(getLanguageCode('')).toBe('translated');
+      expect(getLanguageCode(undefined)).toBe('translated');
+      expect(getLanguageCode(null)).toBe('translated');
     });
   });
 });

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -4,14 +4,14 @@ import { parseCliArgs } from '../src/cli.js';
 describe('CLI', () => {
   describe('parseCliArgs', () => {
     test('should parse required input file path', () => {
-      const args = ['node', 'index.js', 'test.md'];
+      const args = ['node', 'index.js', 'test.md', '--to', 'Japanese'];
       const result = parseCliArgs(args);
 
       expect(result.inputFile).toBe('test.md');
     });
 
     test('should use default values for optional parameters', () => {
-      const args = ['node', 'index.js', 'test.md'];
+      const args = ['node', 'index.js', 'test.md', '--to', 'Japanese'];
       const result = parseCliArgs(args);
 
       expect(result.outputDir).toBe('output/');
@@ -20,21 +20,21 @@ describe('CLI', () => {
     });
 
     test('should parse output directory option', () => {
-      const args = ['node', 'index.js', 'test.md', '--output-dir', 'custom-output/'];
+      const args = ['node', 'index.js', 'test.md', '--to', 'Japanese', '--output-dir', 'custom-output/'];
       const result = parseCliArgs(args);
 
       expect(result.outputDir).toBe('custom-output/');
     });
 
     test('should parse chunk size option', () => {
-      const args = ['node', 'index.js', 'test.md', '--chunk-size', '2000'];
+      const args = ['node', 'index.js', 'test.md', '--to', 'Japanese', '--chunk-size', '2000'];
       const result = parseCliArgs(args);
 
       expect(result.chunkSize).toBe(2000);
     });
 
     test('should parse model option', () => {
-      const args = ['node', 'index.js', 'test.md', '--model', 'gpt-4'];
+      const args = ['node', 'index.js', 'test.md', '--to', 'Japanese', '--model', 'gpt-4'];
       const result = parseCliArgs(args);
 
       expect(result.model).toBe('gpt-4');
@@ -43,6 +43,7 @@ describe('CLI', () => {
     test('should parse all options together', () => {
       const args = [
         'node', 'index.js', 'my-book.md',
+        '--to', 'Japanese',
         '--output-dir', 'translations/',
         '--chunk-size', '3000',
         '--model', 'gpt-4-turbo'
@@ -66,6 +67,7 @@ describe('CLI', () => {
         'node', 'index.js',
         '--model', 'gpt-4',
         'book.md',
+        '--to', 'Japanese',
         '--chunk-size', '5000'
       ];
       const result = parseCliArgs(args);
@@ -83,7 +85,7 @@ describe('CLI', () => {
     });
 
     test('should default rectify to false', () => {
-      const args = ['node', 'index.js', 'test.md'];
+      const args = ['node', 'index.js', 'test.md', '--to', 'Japanese'];
       const result = parseCliArgs(args);
 
       expect(result.rectify).toBe(false);
@@ -112,7 +114,7 @@ describe('CLI', () => {
     });
 
     test('should default pdfToMd to false', () => {
-      const args = ['node', 'index.js', 'test.md'];
+      const args = ['node', 'index.js', 'test.md', '--to', 'Japanese'];
       const result = parseCliArgs(args);
 
       expect(result.pdfToMd).toBe(false);
@@ -138,14 +140,14 @@ describe('CLI', () => {
     });
 
     test('should parse --no-context flag to disable context-aware translation', () => {
-      const args = ['node', 'index.js', 'test.md', '--no-context'];
+      const args = ['node', 'index.js', 'test.md', '--to', 'Japanese', '--no-context'];
       const result = parseCliArgs(args);
 
       expect(result.contextAware).toBe(false);
     });
 
     test('should default contextAware to true', () => {
-      const args = ['node', 'index.js', 'test.md'];
+      const args = ['node', 'index.js', 'test.md', '--to', 'Japanese'];
       const result = parseCliArgs(args);
 
       expect(result.contextAware).toBe(true);
@@ -154,6 +156,7 @@ describe('CLI', () => {
     test('should parse --no-context flag with other options', () => {
       const args = [
         'node', 'index.js', 'book.md',
+        '--to', 'Japanese',
         '--no-context',
         '--output-dir', 'output/',
         '--model', 'gpt-4o'
@@ -163,6 +166,65 @@ describe('CLI', () => {
       expect(result.inputFile).toBe('book.md');
       expect(result.contextAware).toBe(false);
       expect(result.outputDir).toBe('output/');
+      expect(result.model).toBe('gpt-4o');
+    });
+
+    // Target language tests
+    test('should parse --to flag for target language', () => {
+      const args = ['node', 'index.js', 'test.md', '--to', 'German'];
+      const result = parseCliArgs(args);
+
+      expect(result.targetLanguage).toBe('German');
+    });
+
+    test('should accept -t as short form for target language', () => {
+      const args = ['node', 'index.js', 'test.md', '-t', 'French'];
+      const result = parseCliArgs(args);
+
+      expect(result.targetLanguage).toBe('French');
+    });
+
+    test('should handle target language with style description', () => {
+      const args = ['node', 'index.js', 'test.md', '--to', 'business casual German'];
+      const result = parseCliArgs(args);
+
+      expect(result.targetLanguage).toBe('business casual German');
+    });
+
+    test('should throw error when --to is missing in translation mode', () => {
+      const args = ['node', 'index.js', 'test.md'];
+
+      expect(() => parseCliArgs(args)).toThrow(/target language is required/i);
+    });
+
+    test('should not require --to for rectify mode', () => {
+      const args = ['node', 'index.js', 'test.md', '--rectify'];
+      const result = parseCliArgs(args);
+
+      expect(result.rectify).toBe(true);
+      expect(result.targetLanguage).toBeUndefined();
+    });
+
+    test('should not require --to for pdf-to-md mode', () => {
+      const args = ['node', 'index.js', 'test.pdf', '--pdf-to-md'];
+      const result = parseCliArgs(args);
+
+      expect(result.pdfToMd).toBe(true);
+      expect(result.targetLanguage).toBeUndefined();
+    });
+
+    test('should parse --to flag with other options', () => {
+      const args = [
+        'node', 'index.js', 'book.md',
+        '--to', 'Spanish',
+        '--output-dir', 'translations/',
+        '--model', 'gpt-4o'
+      ];
+      const result = parseCliArgs(args);
+
+      expect(result.inputFile).toBe('book.md');
+      expect(result.targetLanguage).toBe('Spanish');
+      expect(result.outputDir).toBe('translations/');
       expect(result.model).toBe('gpt-4o');
     });
   });

--- a/web-app/src/lib/languageCode.ts
+++ b/web-app/src/lib/languageCode.ts
@@ -1,0 +1,91 @@
+/**
+ * Language code utility for converting language names to ISO codes.
+ * Used for naming output files (e.g., book-de.md for German).
+ */
+
+// Language code mapping for common languages
+const LANGUAGE_CODES: Record<string, string> = {
+	japanese: 'ja',
+	german: 'de',
+	french: 'fr',
+	spanish: 'es',
+	italian: 'it',
+	portuguese: 'pt',
+	chinese: 'zh',
+	korean: 'ko',
+	russian: 'ru',
+	arabic: 'ar',
+	dutch: 'nl',
+	swedish: 'sv',
+	norwegian: 'no',
+	danish: 'da',
+	finnish: 'fi',
+	polish: 'pl',
+	turkish: 'tr',
+	hindi: 'hi',
+	thai: 'th',
+	vietnamese: 'vi',
+	indonesian: 'id',
+	greek: 'el',
+	hebrew: 'he',
+	czech: 'cs',
+	hungarian: 'hu',
+	ukrainian: 'uk'
+};
+
+/**
+ * Extracts language code from a target language string.
+ * Handles both simple language names ("Japanese") and style-qualified descriptions
+ * ("business casual German", "formal French").
+ * Returns "translated" for unknown languages.
+ */
+export function getLanguageCode(targetLanguage: string | null | undefined): string {
+	if (!targetLanguage) {
+		return 'translated';
+	}
+
+	const lowerTarget = targetLanguage.toLowerCase();
+
+	// First, check for exact matches
+	if (LANGUAGE_CODES[lowerTarget]) {
+		return LANGUAGE_CODES[lowerTarget];
+	}
+
+	// Look for a known language name anywhere in the string
+	for (const [language, code] of Object.entries(LANGUAGE_CODES)) {
+		if (lowerTarget.includes(language)) {
+			return code;
+		}
+	}
+
+	return 'translated';
+}
+
+/**
+ * Extracts the primary language name from a target language string.
+ * Used for display purposes in UI tabs.
+ * For "business casual German" returns "German".
+ */
+export function getLanguageName(targetLanguage: string | null | undefined): string {
+	if (!targetLanguage) {
+		return 'Translated';
+	}
+
+	const lowerTarget = targetLanguage.toLowerCase();
+
+	// Look for a known language name
+	for (const language of Object.keys(LANGUAGE_CODES)) {
+		if (lowerTarget.includes(language)) {
+			// Capitalize first letter
+			return language.charAt(0).toUpperCase() + language.slice(1);
+		}
+	}
+
+	// If no match, return the input as-is (trimmed, capitalized first letter)
+	const trimmed = targetLanguage.trim();
+	if (trimmed) {
+		return trimmed.charAt(0).toUpperCase() + trimmed.slice(1);
+	}
+
+	return 'Translated';
+}

--- a/web-app/src/lib/languageHistory.ts
+++ b/web-app/src/lib/languageHistory.ts
@@ -1,0 +1,61 @@
+/**
+ * Language history management for storing and retrieving previously used translation languages.
+ * Uses localStorage to persist history across sessions.
+ */
+
+export const LANGUAGE_HISTORY_KEY = 'translation-language-history';
+export const MAX_HISTORY_ITEMS = 10;
+
+/**
+ * Get the language history from localStorage.
+ * Returns an array of language strings, most recent first.
+ */
+export function getLanguageHistory(): string[] {
+	try {
+		const stored = localStorage.getItem(LANGUAGE_HISTORY_KEY);
+		if (!stored) {
+			return [];
+		}
+		const parsed = JSON.parse(stored);
+		if (!Array.isArray(parsed)) {
+			return [];
+		}
+		return parsed;
+	} catch {
+		return [];
+	}
+}
+
+/**
+ * Add a language to the history.
+ * - Most recent is placed at the top
+ * - Duplicates are removed (existing entry moves to top)
+ * - History is limited to MAX_HISTORY_ITEMS
+ * - Empty/whitespace-only strings are ignored
+ */
+export function addLanguageToHistory(language: string): void {
+	const trimmed = language.trim();
+	if (!trimmed) {
+		return;
+	}
+
+	const history = getLanguageHistory();
+
+	// Remove existing entry if present (will be re-added at top)
+	const filtered = history.filter((item) => item !== trimmed);
+
+	// Add to the front (most recent first)
+	filtered.unshift(trimmed);
+
+	// Limit to MAX_HISTORY_ITEMS
+	const limited = filtered.slice(0, MAX_HISTORY_ITEMS);
+
+	localStorage.setItem(LANGUAGE_HISTORY_KEY, JSON.stringify(limited));
+}
+
+/**
+ * Clear all language history.
+ */
+export function clearLanguageHistory(): void {
+	localStorage.removeItem(LANGUAGE_HISTORY_KEY);
+}

--- a/web-app/src/lib/services/translator.ts
+++ b/web-app/src/lib/services/translator.ts
@@ -16,6 +16,7 @@ export interface TranslatorOptions {
 	verbosity?: string;
 	reasoningEffort?: string;
 	maxRetries?: number;
+	targetLanguage?: string;
 }
 
 export interface Translator {
@@ -58,6 +59,7 @@ export function createTranslator(options: TranslatorOptions): Translator {
 	const model = options.model || 'gpt-4o';
 	const contextAware = options.contextAware !== false; // Default to true
 	const verbosity = options.verbosity || 'low';
+	const defaultTargetLanguage = options.targetLanguage || 'Japanese';
 
 	// Helper to check if model is GPT-5.1 family (supports "none", not "minimal")
 	function isGpt51Model(modelName: string): boolean {
@@ -88,11 +90,12 @@ export function createTranslator(options: TranslatorOptions): Translator {
 	async function translateChunk(
 		chunk: string,
 		context: TranslationContext = {},
-		targetLanguage: string = 'Japanese'
+		targetLanguage?: string
 	): Promise<string> {
+		const language = targetLanguage || defaultTargetLanguage;
 		const systemPrompt = contextAware
-			? getContextAwareSystemPrompt(targetLanguage)
-			: getLegacySystemPrompt(targetLanguage);
+			? getContextAwareSystemPrompt(language)
+			: getLegacySystemPrompt(language);
 
 		const userContent = contextAware ? buildContextMessage(chunk, context) : chunk;
 

--- a/web-app/src/lib/services/workflowEngine.ts
+++ b/web-app/src/lib/services/workflowEngine.ts
@@ -165,7 +165,8 @@ export async function runWorkflow(options: WorkflowOptions): Promise<WorkflowRes
 			apiKey,
 			model: translationSettings.model,
 			contextAware: translationSettings.contextAware,
-			reasoningEffort: translationSettings.reasoningEffort
+			reasoningEffort: translationSettings.reasoningEffort,
+			targetLanguage: translationSettings.targetLanguage
 		});
 
 		// Run translation with progress tracking

--- a/web-app/src/lib/storage.ts
+++ b/web-app/src/lib/storage.ts
@@ -5,7 +5,7 @@ const DB_VERSION = 1;
 const STORE_NAME = 'documents';
 
 export type DocumentPhase = 'uploaded' | 'converted' | 'cleaned' | 'translated';
-export type TranslationVariant = 'japanese-only' | 'bilingual';
+export type TranslationVariant = 'japanese-only' | 'translated-only' | 'bilingual';
 
 export interface StoredDocument {
 	id: string;

--- a/web-app/src/lib/workflow.ts
+++ b/web-app/src/lib/workflow.ts
@@ -31,6 +31,7 @@ export interface TranslationSettings {
 	chunkSize: number;
 	reasoningEffort: string;
 	contextAware: boolean;
+	targetLanguage: string;
 }
 
 // Output documents from workflow
@@ -72,7 +73,8 @@ export const DEFAULT_TRANSLATION_SETTINGS: TranslationSettings = {
 	model: 'gpt-5-mini',
 	chunkSize: 4000,
 	reasoningEffort: 'medium',
-	contextAware: true
+	contextAware: true,
+	targetLanguage: ''
 };
 
 // Factory function to create initial workflow state

--- a/web-app/src/routes/+layout.svelte
+++ b/web-app/src/routes/+layout.svelte
@@ -2,8 +2,41 @@
 	import '../app.css';
 	import { page } from '$app/state';
 	import { base } from '$app/paths';
+	import { goto } from '$app/navigation';
+	import { onMount } from 'svelte';
+	import { browser } from '$app/environment';
 
 	let { children } = $props();
+
+	// Track if initial redirect has been performed
+	let initialRedirectDone = $state(false);
+
+	onMount(() => {
+		if (!browser) return;
+
+		const relativePath = getRelativePath(page.url.pathname);
+
+		// Skip redirect if already on settings or help pages
+		if (relativePath.startsWith('/settings')) {
+			initialRedirectDone = true;
+			return;
+		}
+
+		const apiKey = localStorage.getItem('openai_api_key');
+
+		// Only redirect from home page on initial load
+		if (relativePath === '/') {
+			if (!apiKey || apiKey.trim() === '') {
+				// No API key - redirect to settings
+				goto(fullHref('/settings'), { replaceState: true });
+			} else {
+				// API key exists - redirect to workflow
+				goto(fullHref('/workflow'), { replaceState: true });
+			}
+		}
+
+		initialRedirectDone = true;
+	});
 
 	// Primary workflow item (shown at top with separator)
 	const workflowItem = {

--- a/web-app/src/routes/settings/+page.svelte
+++ b/web-app/src/routes/settings/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { browser } from '$app/environment';
+	import { base } from '$app/paths';
 	import { getDocumentsStorageUsed, clearAllDocuments as clearIndexedDBDocuments } from '$lib/storage';
 
 	// API Key state
@@ -120,7 +121,32 @@
 	<div class="space-y-6">
 		<!-- API Key Section -->
 		<div class="bg-white rounded-lg border border-gray-200 p-6">
-			<h2 class="text-lg font-semibold text-gray-900 mb-4">OpenAI API Configuration</h2>
+			<div class="flex items-center justify-between mb-4">
+				<h2 class="text-lg font-semibold text-gray-900">OpenAI API Configuration</h2>
+				<div class="relative">
+					<a
+						href="{base}/settings/api-key-help"
+						target="_blank"
+						rel="noopener noreferrer"
+						class="inline-flex items-center gap-1 text-sm text-blue-600 hover:text-blue-700"
+					>
+						How to get an API key
+						<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+						</svg>
+					</a>
+					{#if !apiKey.trim()}
+						<div
+							data-testid="getting-started-tooltip"
+							class="absolute right-0 top-full mt-2 w-64 p-3 bg-blue-600 text-white text-sm rounded-lg shadow-lg z-10"
+						>
+							<div class="absolute -top-2 right-4 w-0 h-0 border-l-8 border-r-8 border-b-8 border-transparent border-b-blue-600"></div>
+							<p class="font-medium mb-1">New here?</p>
+							<p>Start by reading this help page, then get your API key from OpenAI.</p>
+						</div>
+					{/if}
+				</div>
+			</div>
 
 			<div class="space-y-4">
 				<div>

--- a/web-app/src/routes/settings/api-key-help/+page.svelte
+++ b/web-app/src/routes/settings/api-key-help/+page.svelte
@@ -1,0 +1,247 @@
+<script lang="ts">
+	import { base } from '$app/paths';
+</script>
+
+<div class="max-w-3xl">
+	<div class="mb-6">
+		<a
+			href="{base}/settings"
+			class="inline-flex items-center gap-2 text-blue-600 hover:text-blue-700 text-sm"
+		>
+			<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+				<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7" />
+			</svg>
+			Back to Settings
+		</a>
+	</div>
+
+	<h1 class="text-2xl font-bold text-gray-900 mb-6">How to Get Your OpenAI API Key</h1>
+
+	<div class="space-y-8">
+		<!-- What is an API Key -->
+		<section class="bg-white rounded-lg border border-gray-200 p-6">
+			<h2 class="text-lg font-semibold text-gray-900 mb-3">What is an API Key?</h2>
+			<p class="text-gray-600 mb-3">
+				An API key is like a password that lets this app communicate with OpenAI's translation
+				services. Think of it as your personal access code that allows the app to use AI-powered
+				translation on your behalf.
+			</p>
+			<p class="text-gray-600">
+				Without an API key, the app cannot connect to OpenAI's servers to perform translations.
+				Each API key is unique to your account and tracks your usage.
+			</p>
+		</section>
+
+		<!-- Step by Step Instructions -->
+		<section class="bg-white rounded-lg border border-gray-200 p-6">
+			<h2 class="text-lg font-semibold text-gray-900 mb-4">Step-by-Step Instructions</h2>
+
+			<div class="space-y-6">
+				<div class="flex gap-4">
+					<div class="flex-shrink-0 w-8 h-8 bg-blue-100 text-blue-700 rounded-full flex items-center justify-center font-bold">
+						1
+					</div>
+					<div>
+						<h3 class="font-medium text-gray-900 mb-1">Create an OpenAI Account</h3>
+						<p class="text-gray-600 mb-2">
+							Go to OpenAI's platform and sign up for a free account. You can use your email,
+							Google, Microsoft, or Apple account.
+						</p>
+						<a
+							href="https://platform.openai.com/signup"
+							target="_blank"
+							rel="noopener noreferrer"
+							class="inline-flex items-center gap-1 text-blue-600 hover:text-blue-700"
+						>
+							Visit platform.openai.com
+							<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+								<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+							</svg>
+						</a>
+					</div>
+				</div>
+
+				<div class="flex gap-4">
+					<div class="flex-shrink-0 w-8 h-8 bg-blue-100 text-blue-700 rounded-full flex items-center justify-center font-bold">
+						2
+					</div>
+					<div>
+						<h3 class="font-medium text-gray-900 mb-1">Verify Your Account</h3>
+						<p class="text-gray-600">
+							OpenAI will ask you to verify your email address and phone number. This helps
+							secure your account and prevents misuse.
+						</p>
+					</div>
+				</div>
+
+				<div class="flex gap-4">
+					<div class="flex-shrink-0 w-8 h-8 bg-blue-100 text-blue-700 rounded-full flex items-center justify-center font-bold">
+						3
+					</div>
+					<div>
+						<h3 class="font-medium text-gray-900 mb-1">Navigate to API Keys</h3>
+						<p class="text-gray-600 mb-2">
+							Once logged in, click on "API keys" in the left sidebar, or go directly to the API keys page.
+						</p>
+						<a
+							href="https://platform.openai.com/api-keys"
+							target="_blank"
+							rel="noopener noreferrer"
+							class="inline-flex items-center gap-1 text-blue-600 hover:text-blue-700"
+						>
+							Go to API Keys page
+							<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+								<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+							</svg>
+						</a>
+					</div>
+				</div>
+
+				<div class="flex gap-4">
+					<div class="flex-shrink-0 w-8 h-8 bg-blue-100 text-blue-700 rounded-full flex items-center justify-center font-bold">
+						4
+					</div>
+					<div>
+						<h3 class="font-medium text-gray-900 mb-1">Create a New API Key</h3>
+						<p class="text-gray-600">
+							Click the "+ Create new secret key" button. Give your key a name (like "Book Translate")
+							so you can identify it later. Click "Create secret key".
+						</p>
+					</div>
+				</div>
+
+				<div class="flex gap-4">
+					<div class="flex-shrink-0 w-8 h-8 bg-blue-100 text-blue-700 rounded-full flex items-center justify-center font-bold">
+						5
+					</div>
+					<div>
+						<h3 class="font-medium text-gray-900 mb-1">Copy Your Key Immediately</h3>
+						<p class="text-gray-600">
+							<strong>Important:</strong> Copy your API key right away! OpenAI will only show it once.
+							If you lose it, you'll need to create a new one. Your key will look something like:
+							<code class="bg-gray-100 px-2 py-1 rounded text-sm">sk-...</code>
+						</p>
+					</div>
+				</div>
+
+				<div class="flex gap-4">
+					<div class="flex-shrink-0 w-8 h-8 bg-blue-100 text-blue-700 rounded-full flex items-center justify-center font-bold">
+						6
+					</div>
+					<div>
+						<h3 class="font-medium text-gray-900 mb-1">Paste in Settings</h3>
+						<p class="text-gray-600">
+							Come back to this app, go to Settings, and paste your API key in the API Key field.
+							Click "Save" to store it securely in your browser.
+						</p>
+					</div>
+				</div>
+			</div>
+		</section>
+
+		<!-- Billing Information -->
+		<section class="bg-white rounded-lg border border-gray-200 p-6">
+			<h2 class="text-lg font-semibold text-gray-900 mb-3">About Costs and Billing</h2>
+			<p class="text-gray-600 mb-3">
+				Using OpenAI's API costs money based on how much you use it. New accounts often receive
+				free credits (around $5) to get started, which is enough for initial testing.
+			</p>
+			<p class="text-gray-600 mb-3">
+				For ongoing use, you'll need to add a payment method to your OpenAI account. The cost
+				depends on how much text you translate. Translating a typical book might cost a few dollars.
+			</p>
+			<p class="text-gray-600">
+				You can set spending limits in your OpenAI account settings to prevent unexpected charges.
+			</p>
+		</section>
+
+		<!-- Rate Limits Warning -->
+		<section class="bg-amber-50 border border-amber-200 rounded-lg p-6">
+			<div class="flex gap-3">
+				<svg class="w-6 h-6 text-amber-600 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+				</svg>
+				<div>
+					<h2 class="text-lg font-semibold text-amber-800 mb-2">About Rate Limits</h2>
+					<p class="text-amber-700 mb-3">
+						New OpenAI accounts have <strong>rate limits</strong> that restrict how many requests
+						you can make per minute. This is normal and not a problem with your account.
+					</p>
+					<p class="text-amber-700 mb-3">
+						<strong>What this means:</strong> If you're translating a large document, the app might
+						need to pause briefly between sections. You might see "rate limit exceeded" messages -
+						the app will automatically retry after a short wait.
+					</p>
+					<p class="text-amber-700">
+						<strong>Good news:</strong> Your rate limits automatically increase as you use the API
+						more and your account builds a track record. After a few successful payments, you'll
+						have much higher limits.
+					</p>
+				</div>
+			</div>
+		</section>
+
+		<!-- Security Warning -->
+		<section class="bg-red-50 border border-red-200 rounded-lg p-6">
+			<div class="flex gap-3">
+				<svg class="w-6 h-6 text-red-600 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 15v2m-6 4h12a2 2 0 002-2v-6a2 2 0 00-2-2H6a2 2 0 00-2 2v6a2 2 0 002 2zm10-10V7a4 4 0 00-8 0v4h8z" />
+				</svg>
+				<div>
+					<h2 class="text-lg font-semibold text-red-800 mb-2">Keep Your API Key Safe</h2>
+					<p class="text-red-700 mb-3">
+						Your API key is like a password. <strong>Never share it</strong> with anyone, and don't
+						post it in public places like forums, emails, or social media.
+					</p>
+					<p class="text-red-700 mb-3">
+						If someone else gets your key, they can use it to make requests that will be billed to
+						your account. If you think your key has been compromised, delete it immediately in your
+						OpenAI dashboard and create a new one.
+					</p>
+					<p class="text-red-700">
+						This app stores your API key only in your browser's local storage. It is never sent to
+						any server other than OpenAI's official API.
+					</p>
+				</div>
+			</div>
+		</section>
+
+		<!-- Troubleshooting -->
+		<section class="bg-white rounded-lg border border-gray-200 p-6">
+			<h2 class="text-lg font-semibold text-gray-900 mb-3">Troubleshooting</h2>
+			<div class="space-y-4">
+				<div>
+					<h3 class="font-medium text-gray-900">My key isn't working</h3>
+					<p class="text-gray-600 text-sm">
+						Make sure you copied the entire key including the "sk-" prefix. Also check that your
+						OpenAI account has billing set up if your free credits have been used.
+					</p>
+				</div>
+				<div>
+					<h3 class="font-medium text-gray-900">I see "rate limit" errors</h3>
+					<p class="text-gray-600 text-sm">
+						This is normal for new accounts. The app will automatically retry. If it persists,
+						wait a few minutes and try again, or consider processing smaller documents.
+					</p>
+				</div>
+				<div>
+					<h3 class="font-medium text-gray-900">I lost my API key</h3>
+					<p class="text-gray-600 text-sm">
+						You cannot retrieve a lost key. Go to the OpenAI API Keys page, delete the old key,
+						and create a new one.
+					</p>
+				</div>
+			</div>
+		</section>
+
+		<!-- Back to Settings -->
+		<div class="text-center">
+			<a
+				href="{base}/settings"
+				class="inline-flex items-center gap-2 px-6 py-3 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+			>
+				Return to Settings
+			</a>
+		</div>
+	</div>
+</div>

--- a/web-app/src/routes/settings/api-key-help/+page.svelte
+++ b/web-app/src/routes/settings/api-key-help/+page.svelte
@@ -75,8 +75,38 @@
 				</div>
 
 				<div class="flex gap-4">
-					<div class="flex-shrink-0 w-8 h-8 bg-blue-100 text-blue-700 rounded-full flex items-center justify-center font-bold">
+					<div class="flex-shrink-0 w-8 h-8 bg-green-100 text-green-700 rounded-full flex items-center justify-center font-bold">
 						3
+					</div>
+					<div>
+						<h3 class="font-medium text-gray-900 mb-1">Add a Payment Method & Purchase Credits</h3>
+						<p class="text-gray-600 mb-2">
+							<strong>Do this now:</strong> OpenAI uses prepaid billing, which means your API key
+							won't work until you've added a payment method and purchased credits. Without credits,
+							you'll get "insufficient quota" errors when trying to use the translation features.
+						</p>
+						<p class="text-gray-600 mb-3">
+							Go to your billing settings, click "Add payment method", and enter your credit or debit
+							card details. Then click "Add to credit balance" to purchase your initial credits
+							($5-10 is plenty to get started and test the app).
+						</p>
+						<a
+							href="https://platform.openai.com/settings/organization/billing/payment-methods"
+							target="_blank"
+							rel="noopener noreferrer"
+							class="inline-flex items-center gap-1 text-blue-600 hover:text-blue-700"
+						>
+							Go to Billing & Payment Methods
+							<svg class="w-4 h-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+								<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+							</svg>
+						</a>
+					</div>
+				</div>
+
+				<div class="flex gap-4">
+					<div class="flex-shrink-0 w-8 h-8 bg-blue-100 text-blue-700 rounded-full flex items-center justify-center font-bold">
+						4
 					</div>
 					<div>
 						<h3 class="font-medium text-gray-900 mb-1">Navigate to API Keys</h3>
@@ -99,7 +129,7 @@
 
 				<div class="flex gap-4">
 					<div class="flex-shrink-0 w-8 h-8 bg-blue-100 text-blue-700 rounded-full flex items-center justify-center font-bold">
-						4
+						5
 					</div>
 					<div>
 						<h3 class="font-medium text-gray-900 mb-1">Create a New API Key</h3>
@@ -112,7 +142,7 @@
 
 				<div class="flex gap-4">
 					<div class="flex-shrink-0 w-8 h-8 bg-blue-100 text-blue-700 rounded-full flex items-center justify-center font-bold">
-						5
+						6
 					</div>
 					<div>
 						<h3 class="font-medium text-gray-900 mb-1">Copy Your Key Immediately</h3>
@@ -126,7 +156,7 @@
 
 				<div class="flex gap-4">
 					<div class="flex-shrink-0 w-8 h-8 bg-blue-100 text-blue-700 rounded-full flex items-center justify-center font-bold">
-						6
+						7
 					</div>
 					<div>
 						<h3 class="font-medium text-gray-900 mb-1">Paste in Settings</h3>
@@ -143,15 +173,22 @@
 		<section class="bg-white rounded-lg border border-gray-200 p-6">
 			<h2 class="text-lg font-semibold text-gray-900 mb-3">About Costs and Billing</h2>
 			<p class="text-gray-600 mb-3">
-				Using OpenAI's API costs money based on how much you use it. New accounts often receive
-				free credits (around $5) to get started, which is enough for initial testing.
+				OpenAI uses <strong>prepaid billing</strong> for API access. This means you must purchase
+				credits before you can use the API. Your API requests will fail with "insufficient quota"
+				errors if you haven't added credits to your account.
 			</p>
 			<p class="text-gray-600 mb-3">
-				For ongoing use, you'll need to add a payment method to your OpenAI account. The cost
-				depends on how much text you translate. Translating a typical book might cost a few dollars.
+				The cost depends on how much text you translate. Translating a typical book chapter might
+				cost a few cents; an entire book might cost a few dollars. Starting with $5-10 in credits
+				is plenty to experiment and translate several documents.
+			</p>
+			<p class="text-gray-600 mb-3">
+				You can enable <strong>auto-recharge</strong> in your billing settings to automatically
+				add credits when your balance runs low, or manually add credits as needed.
 			</p>
 			<p class="text-gray-600">
-				You can set spending limits in your OpenAI account settings to prevent unexpected charges.
+				<strong>Tip:</strong> Set a monthly budget limit in your OpenAI account settings to prevent
+				unexpected charges. Purchased credits expire after 1 year.
 			</p>
 		</section>
 
@@ -211,10 +248,12 @@
 			<h2 class="text-lg font-semibold text-gray-900 mb-3">Troubleshooting</h2>
 			<div class="space-y-4">
 				<div>
-					<h3 class="font-medium text-gray-900">My key isn't working</h3>
+					<h3 class="font-medium text-gray-900">My key isn't working / "insufficient quota" error</h3>
 					<p class="text-gray-600 text-sm">
-						Make sure you copied the entire key including the "sk-" prefix. Also check that your
-						OpenAI account has billing set up if your free credits have been used.
+						Make sure you copied the entire key including the "sk-" prefix. Most commonly, this error
+						means you haven't added a payment method and purchased credits yet. Go to your
+						<a href="https://platform.openai.com/settings/organization/billing/overview" target="_blank" rel="noopener noreferrer" class="text-blue-600 hover:text-blue-700">OpenAI billing page</a>
+						to add credits.
 					</p>
 				</div>
 				<div>

--- a/web-app/src/routes/translate/+page.svelte
+++ b/web-app/src/routes/translate/+page.svelte
@@ -328,7 +328,7 @@
 
 		<div class="relative">
 			<label class="block text-sm font-medium text-gray-700 mb-2">
-				Target Language: <span class="text-red-500">*</span>
+				Target Language and Tone: <span class="text-red-500">*</span>
 			</label>
 			<input
 				data-testid="target-language-input"

--- a/web-app/src/routes/translate/+page.svelte
+++ b/web-app/src/routes/translate/+page.svelte
@@ -20,7 +20,7 @@
 		getLanguageHistory,
 		addLanguageToHistory
 	} from '$lib/languageHistory';
-	import { getLanguageCode, getLanguageName } from '$lib/languageCode';
+	import { getLanguageCode } from '$lib/languageCode';
 
 	// Browser services for direct OpenAI calls
 	import { chunkBySize } from '$lib/services/chunker';
@@ -110,9 +110,6 @@
 
 	// Get the selected document info (not full document with content)
 	let selectedDocInfo = $derived(documents.find((doc) => doc.id === selectedDocId));
-
-	// Derived language display name for tabs
-	let displayLanguageName = $derived(getLanguageName(targetLanguage));
 
 	// Validation: language is required
 	let languageError = $derived(languageTouched && !targetLanguage.trim() ? 'Target language is required' : '');
@@ -442,7 +439,7 @@
 						? 'border-blue-600 text-blue-600'
 						: 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'}"
 				>
-					{displayLanguageName} Only
+					Target Language Only
 				</button>
 				<button
 					role="tab"

--- a/web-app/tests/e2e/api-key-help.spec.ts
+++ b/web-app/tests/e2e/api-key-help.spec.ts
@@ -1,0 +1,178 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('API Key Help Page', () => {
+	test('help page is accessible at /settings/api-key-help', async ({ page }) => {
+		await page.goto('/settings/api-key-help');
+
+		await expect(page).toHaveURL('/settings/api-key-help');
+	});
+
+	test('displays page title about getting an API key', async ({ page }) => {
+		await page.goto('/settings/api-key-help');
+
+		// Should have a clear title
+		const heading = page.locator('h1');
+		await expect(heading).toBeVisible();
+		await expect(heading).toContainText(/api key/i);
+	});
+
+	test('explains what an API key is', async ({ page }) => {
+		await page.goto('/settings/api-key-help');
+
+		// Should explain what an API key is for non-technical users
+		await expect(page.getByRole('heading', { name: /what is an api key/i })).toBeVisible();
+		await expect(page.getByText(/like a password/i).first()).toBeVisible();
+	});
+
+	test('provides step-by-step instructions to get an API key', async ({ page }) => {
+		await page.goto('/settings/api-key-help');
+
+		// Should have numbered steps or clear instructions
+		// Check for key steps: sign up, navigate to API keys, create key
+		await expect(page.getByRole('heading', { name: /step-by-step/i })).toBeVisible();
+		await expect(page.getByRole('heading', { name: /create an openai account/i })).toBeVisible();
+	});
+
+	test('includes link to OpenAI platform', async ({ page }) => {
+		await page.goto('/settings/api-key-help');
+
+		// Should have a link to OpenAI's platform
+		const openAILink = page.getByRole('link', { name: /openai|platform\.openai\.com/i });
+		await expect(openAILink).toBeVisible();
+
+		// Link should open in new tab
+		await expect(openAILink).toHaveAttribute('target', '_blank');
+	});
+
+	test('explains rate limiting for new accounts', async ({ page }) => {
+		await page.goto('/settings/api-key-help');
+
+		// Should mention rate limiting
+		await expect(page.getByRole('heading', { name: /about rate limits/i })).toBeVisible();
+
+		// Should explain what it means in simple terms
+		await expect(page.getByText(/how many requests/i)).toBeVisible();
+	});
+
+	test('explains API cost/billing basics', async ({ page }) => {
+		await page.goto('/settings/api-key-help');
+
+		// Should mention that API usage costs money or has a free tier
+		await expect(page.getByText(/billing|payment|credit|cost|free/i).first()).toBeVisible();
+	});
+
+	test('has a link back to settings page', async ({ page }) => {
+		await page.goto('/settings/api-key-help');
+
+		// Should have a way to go back to settings (there are two: top and bottom)
+		const backLink = page.getByRole('link', { name: /back to settings/i }).first();
+		await expect(backLink).toBeVisible();
+
+		// Use force click to bypass any stability issues
+		await backLink.click({ force: true });
+		await expect(page).toHaveURL('/settings');
+	});
+
+	test('includes security warning about API key', async ({ page }) => {
+		await page.goto('/settings/api-key-help');
+
+		// Should warn users to keep their API key safe
+		await expect(page.getByText(/secret|secure|never share|protect|safe/i).first()).toBeVisible();
+	});
+});
+
+test.describe('Settings Page - Help Link', () => {
+	test('settings page has a link to API key help', async ({ page }) => {
+		await page.goto('/settings');
+
+		// Should have a help link near the API key section
+		const helpLink = page.getByRole('link', { name: /how.*get|help|get.*api.*key/i });
+		await expect(helpLink).toBeVisible();
+	});
+
+	test('help link opens in new tab', async ({ page }) => {
+		await page.goto('/settings');
+
+		// The help link should have target="_blank"
+		const helpLink = page.getByRole('link', { name: /how.*get|help|get.*api.*key/i });
+		await expect(helpLink).toHaveAttribute('target', '_blank');
+	});
+
+	test('help link points to the correct page', async ({ page }) => {
+		await page.goto('/settings');
+
+		const helpLink = page.getByRole('link', { name: /how.*get|help|get.*api.*key/i });
+		const href = await helpLink.getAttribute('href');
+
+		// Should point to the help page
+		expect(href).toMatch(/api-key-help/);
+	});
+});
+
+test.describe('Settings Page - Getting Started Tooltip', () => {
+	test.beforeEach(async ({ page }) => {
+		// Clear localStorage to ensure API key is empty
+		await page.goto('/settings');
+		await page.evaluate(() => localStorage.clear());
+		await page.reload();
+	});
+
+	test('shows getting started tooltip when API key is empty', async ({ page }) => {
+		await page.goto('/settings');
+
+		// Should show a tooltip/callout when API key is empty
+		const tooltip = page.locator('[data-testid="getting-started-tooltip"]');
+		await expect(tooltip).toBeVisible();
+	});
+
+	test('tooltip contains helpful guidance text', async ({ page }) => {
+		await page.goto('/settings');
+
+		// Should have guidance text about reading help and getting API key
+		const tooltip = page.locator('[data-testid="getting-started-tooltip"]');
+		await expect(tooltip).toContainText(/start|help|api key/i);
+	});
+
+	test('tooltip disappears when API key has text', async ({ page }) => {
+		await page.goto('/settings');
+
+		// Initially tooltip should be visible
+		const tooltip = page.locator('[data-testid="getting-started-tooltip"]');
+		await expect(tooltip).toBeVisible();
+
+		// Type something in the API key field
+		const apiKeyInput = page.locator('#api-key');
+		await apiKeyInput.fill('sk-test');
+
+		// Tooltip should now be hidden
+		await expect(tooltip).not.toBeVisible();
+	});
+
+	test('tooltip reappears when API key is cleared', async ({ page }) => {
+		await page.goto('/settings');
+
+		const tooltip = page.locator('[data-testid="getting-started-tooltip"]');
+		const apiKeyInput = page.locator('#api-key');
+
+		// Type something - tooltip should hide
+		await apiKeyInput.fill('sk-test');
+		await expect(tooltip).not.toBeVisible();
+
+		// Clear the field - tooltip should reappear
+		await apiKeyInput.fill('');
+		await expect(tooltip).toBeVisible();
+	});
+
+	test('tooltip is not shown when API key is already saved', async ({ page }) => {
+		// Set up an API key before navigating
+		await page.goto('/settings');
+		await page.evaluate(() => {
+			localStorage.setItem('openai_api_key', 'sk-saved-key');
+		});
+		await page.reload();
+
+		// Tooltip should not be visible
+		const tooltip = page.locator('[data-testid="getting-started-tooltip"]');
+		await expect(tooltip).not.toBeVisible();
+	});
+});

--- a/web-app/tests/e2e/api-key-help.spec.ts
+++ b/web-app/tests/e2e/api-key-help.spec.ts
@@ -36,8 +36,8 @@ test.describe('API Key Help Page', () => {
 	test('includes link to OpenAI platform', async ({ page }) => {
 		await page.goto('/settings/api-key-help');
 
-		// Should have a link to OpenAI's platform
-		const openAILink = page.getByRole('link', { name: /openai|platform\.openai\.com/i });
+		// Should have a link to OpenAI's platform (signup link)
+		const openAILink = page.getByRole('link', { name: 'Visit platform.openai.com' });
 		await expect(openAILink).toBeVisible();
 
 		// Link should open in new tab

--- a/web-app/tests/e2e/initial-routing.spec.ts
+++ b/web-app/tests/e2e/initial-routing.spec.ts
@@ -1,0 +1,122 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Initial Routing Based on API Key', () => {
+	test.describe('when API key is not configured', () => {
+		test.beforeEach(async ({ page }) => {
+			// Clear localStorage before each test
+			await page.goto('/settings');
+			await page.evaluate(() => localStorage.clear());
+		});
+
+		test('redirects from home page to settings when API key is empty', async ({ page }) => {
+			await page.goto('/');
+
+			// Should redirect to settings
+			await expect(page).toHaveURL('/settings');
+		});
+
+		test('does not redirect if already on settings page', async ({ page }) => {
+			await page.goto('/settings');
+
+			// Should stay on settings
+			await expect(page).toHaveURL('/settings');
+		});
+
+		test('does not redirect if on api-key-help page', async ({ page }) => {
+			await page.goto('/settings/api-key-help');
+
+			// Should stay on help page
+			await expect(page).toHaveURL('/settings/api-key-help');
+		});
+
+		test('allows direct navigation to workflow without API key', async ({ page }) => {
+			// Direct navigation to workflow should work (app shows error when user tries to use it)
+			await page.goto('/workflow');
+
+			// Should stay on workflow
+			await expect(page).toHaveURL('/workflow');
+		});
+	});
+
+	test.describe('when API key is configured', () => {
+		test.beforeEach(async ({ page }) => {
+			// Set up an API key before each test
+			await page.goto('/settings');
+			await page.evaluate(() => {
+				localStorage.setItem('openai_api_key', 'sk-test-key-12345');
+			});
+		});
+
+		test('redirects from home page to workflow when API key is set', async ({ page }) => {
+			await page.goto('/');
+
+			// Should redirect to workflow (One Step Translation)
+			await expect(page).toHaveURL('/workflow');
+		});
+
+		test('stays on workflow page when API key is set', async ({ page }) => {
+			await page.goto('/workflow');
+
+			// Should stay on workflow
+			await expect(page).toHaveURL('/workflow');
+		});
+
+		test('can still navigate to settings when API key is set', async ({ page }) => {
+			await page.goto('/settings');
+
+			// Should stay on settings
+			await expect(page).toHaveURL('/settings');
+		});
+
+		test('can navigate to other pages when API key is set', async ({ page }) => {
+			await page.goto('/convert');
+
+			// Should stay on convert
+			await expect(page).toHaveURL('/convert');
+		});
+	});
+
+	test.describe('sidebar navigation works after redirect', () => {
+		test('sidebar is visible and clickable after redirect to workflow', async ({ page }) => {
+			// Set up API key and load home page (will redirect to workflow)
+			await page.goto('/settings');
+			await page.evaluate(() => {
+				localStorage.setItem('openai_api_key', 'sk-test-key-12345');
+			});
+			await page.goto('/');
+
+			// Wait for redirect to complete
+			await expect(page).toHaveURL('/workflow');
+
+			// Verify sidebar navigation links are visible
+			const convertLink = page.getByRole('link', { name: /convert pdf/i });
+			await expect(convertLink).toBeVisible();
+
+			// Use force click to bypass any overlay/stability issues
+			await convertLink.click({ force: true });
+
+			// Should navigate to convert page
+			await expect(page).toHaveURL('/convert');
+		});
+
+		test('sidebar is visible and clickable after redirect to settings', async ({ page }) => {
+			// Clear API key and load home page (will redirect to settings)
+			await page.goto('/settings');
+			await page.evaluate(() => localStorage.clear());
+			await page.goto('/');
+
+			// Wait for redirect to complete
+			await expect(page).toHaveURL('/settings');
+
+			// Verify sidebar navigation links are visible
+			const convertLink = page.getByRole('link', { name: /convert pdf/i });
+			await expect(convertLink).toBeVisible();
+
+			// Use force click to bypass any overlay/stability issues
+			await convertLink.click({ force: true });
+
+			// Should navigate to convert page
+			await expect(page).toHaveURL('/convert');
+		});
+	});
+});

--- a/web-app/tests/e2e/translate.spec.ts
+++ b/web-app/tests/e2e/translate.spec.ts
@@ -125,6 +125,9 @@ test.describe('Document Translation', () => {
 		const select = page.locator('select').first();
 		await select.selectOption('doc_md_123');
 
+		// Fill in target language (required)
+		await page.getByTestId('target-language-input').fill('Japanese');
+
 		// Button should now be enabled
 		const button = page.locator('button', { hasText: 'Start Translation' });
 		await expect(button).toBeEnabled();
@@ -148,13 +151,15 @@ test.describe('Document Translation', () => {
 
 		await page.goto('/translate');
 
-		// Select the document
+		// Select the document and fill language
 		const select = page.locator('select').first();
 		await select.selectOption('doc_md_123');
+		await page.getByTestId('target-language-input').fill('Japanese');
 
 		// Click translate
 		const button = page.locator('button', { hasText: 'Start Translation' });
-		await button.click();
+		await expect(button).toBeEnabled({ timeout: 5000 });
+		await button.click({ force: true });
 
 		// Should show loading state - button text changes to "Translating..."
 		await expect(page.getByText('Translating...')).toBeVisible({ timeout: 1000 });
@@ -180,9 +185,12 @@ test.describe('Document Translation', () => {
 
 		await page.goto('/translate');
 
-		// Select the document and click translate
+		// Select the document, fill language, and click translate
 		await page.locator('select').first().selectOption('doc_md_123');
-		await page.locator('button', { hasText: 'Start Translation' }).click();
+		await page.getByTestId('target-language-input').fill('Japanese');
+		const button = page.locator('button', { hasText: 'Start Translation' });
+		await expect(button).toBeEnabled({ timeout: 5000 });
+		await button.click({ force: true });
 
 		// Wait for result tabs to appear
 		await expect(page.getByRole('tab', { name: /japanese only/i })).toBeVisible({ timeout: 10000 });
@@ -214,9 +222,12 @@ test.describe('Document Translation', () => {
 
 		await page.goto('/translate');
 
-		// Select the document and click translate
+		// Select the document, fill language, and click translate
 		await page.locator('select').first().selectOption('doc_md_123');
-		await page.locator('button', { hasText: 'Start Translation' }).click();
+		await page.getByTestId('target-language-input').fill('Japanese');
+		const button = page.locator('button', { hasText: 'Start Translation' });
+		await expect(button).toBeEnabled({ timeout: 5000 });
+		await button.click({ force: true });
 
 		// Should display tabs for both translation types
 		await expect(page.getByRole('tab', { name: /japanese only/i })).toBeVisible({ timeout: 10000 });
@@ -244,9 +255,12 @@ test.describe('Document Translation', () => {
 
 		await page.goto('/translate');
 
-		// Select the document and click translate
+		// Select the document, fill language, and click translate
 		await page.locator('select').first().selectOption('doc_md_123');
-		await page.locator('button', { hasText: 'Start Translation' }).click();
+		await page.getByTestId('target-language-input').fill('Japanese');
+		const button = page.locator('button', { hasText: 'Start Translation' });
+		await expect(button).toBeEnabled({ timeout: 5000 });
+		await button.click({ force: true });
 
 		// Wait for translation to complete (button returns to normal state)
 		await expect(page.locator('button', { hasText: 'Start Translation' })).toBeEnabled({
@@ -256,7 +270,7 @@ test.describe('Document Translation', () => {
 		// Check IndexedDB for the new documents
 		const docs = await getAllDocumentsFromIndexedDB(page);
 
-		// Should have 3 documents now: original + japanese-only + bilingual
+		// Should have 3 documents now: original + translated-only + bilingual
 		expect(docs.length).toBe(3);
 
 		const japaneseDoc = docs.find((d) => d.name.includes('-ja.md'));
@@ -264,7 +278,7 @@ test.describe('Document Translation', () => {
 		expect(japaneseDoc!.name).toBe('test-book-ja.md');
 		expect(japaneseDoc!.content).toBe('# テスト');
 		expect(japaneseDoc!.phase).toBe('translated');
-		expect(japaneseDoc!.variant).toBe('japanese-only');
+		expect(japaneseDoc!.variant).toBe('translated-only');
 		expect(japaneseDoc!.sourceDocumentId).toBe('doc_md_123');
 
 		const bilingualDoc = docs.find((d) => d.name.includes('-bilingual.md'));
@@ -296,9 +310,12 @@ test.describe('Document Translation', () => {
 
 		await page.goto('/translate');
 
-		// Select the document and click translate
+		// Select the document, fill language, and click translate
 		await page.locator('select').first().selectOption('doc_md_123');
-		await page.locator('button', { hasText: 'Start Translation' }).click();
+		await page.getByTestId('target-language-input').fill('Japanese');
+		const button = page.locator('button', { hasText: 'Start Translation' });
+		await expect(button).toBeEnabled({ timeout: 5000 });
+		await button.click({ force: true });
 
 		// Should display error message (error text from browser service)
 		await expect(page.getByText(/invalid api key|error|failed/i)).toBeVisible({ timeout: 10000 });
@@ -322,10 +339,12 @@ test.describe('Document Translation', () => {
 
 		await page.goto('/translate');
 
-		// Select the document and click translate
+		// Select the document, fill language, and click translate
 		await page.locator('select').first().selectOption('doc_md_123');
+		await page.getByTestId('target-language-input').fill('Japanese');
 		const button = page.locator('button', { hasText: 'Start Translation' });
-		await button.click();
+		await expect(button).toBeEnabled({ timeout: 5000 });
+		await button.click({ force: true });
 
 		// Button should return to normal state after translation
 		await expect(button).toBeEnabled({ timeout: 10000 });
@@ -350,9 +369,12 @@ test.describe('Document Translation', () => {
 
 		await page.goto('/translate');
 
-		// Select the document and click translate
+		// Select the document, fill language, and click translate
 		await page.locator('select').first().selectOption('doc_md_123');
-		await page.locator('button', { hasText: 'Start Translation' }).click();
+		await page.getByTestId('target-language-input').fill('Japanese');
+		const button = page.locator('button', { hasText: 'Start Translation' });
+		await expect(button).toBeEnabled({ timeout: 5000 });
+		await button.click({ force: true });
 
 		// Wait for results
 		await expect(page.getByRole('tab', { name: /japanese only/i })).toBeVisible({ timeout: 10000 });
@@ -361,7 +383,7 @@ test.describe('Document Translation', () => {
 		await expect(page.getByText('日本語だけ')).toBeVisible();
 
 		// Click bilingual tab
-		await page.getByRole('tab', { name: /bilingual/i }).click();
+		await page.getByRole('tab', { name: /bilingual/i }).click({ force: true });
 
 		// Should now show bilingual content with English
 		await expect(page.getByText('English Only')).toBeVisible();
@@ -428,8 +450,7 @@ test.describe('Model Selection', () => {
 		const modelSelect = page.getByTestId('model-select');
 		await expect(modelSelect).toHaveValue('gpt-5-mini'); // Verify initial value
 
-		// Click and select to ensure proper interaction
-		await modelSelect.click();
+		// Select gpt-4.1
 		await modelSelect.selectOption('gpt-4.1');
 
 		// Wait for selection to complete
@@ -452,8 +473,7 @@ test.describe('Model Selection', () => {
 		const modelSelect = page.getByTestId('model-select');
 		await expect(modelSelect).toHaveValue('gpt-5-mini'); // Verify initial value
 
-		// Click and select to ensure proper interaction
-		await modelSelect.click();
+		// Select gpt-4.1-mini
 		await modelSelect.selectOption('gpt-4.1-mini');
 
 		// Wait for selection to complete
@@ -544,15 +564,17 @@ test.describe('Model Selection', () => {
 
 		// Select gpt-5.1 model
 		const modelSelect = page.getByTestId('model-select');
-		await modelSelect.click();
 		await modelSelect.selectOption('gpt-5.1');
 		await expect(modelSelect).toHaveValue('gpt-5.1');
 
-		// Select the document
+		// Select the document and fill language
 		await page.locator('select').first().selectOption('doc_md_123');
+		await page.getByTestId('target-language-input').fill('Japanese');
 
 		// Click translate
-		await page.locator('button', { hasText: 'Start Translation' }).click();
+		const button = page.locator('button', { hasText: 'Start Translation' });
+		await expect(button).toBeEnabled({ timeout: 5000 });
+		await button.click({ force: true });
 
 		// Wait for result
 		await expect(page.getByRole('tab', { name: /japanese only/i })).toBeVisible({ timeout: 10000 });
@@ -588,15 +610,17 @@ test.describe('Model Selection', () => {
 
 		// Select gpt-4.1 model (non-5 series)
 		const modelSelect = page.getByTestId('model-select');
-		await modelSelect.click();
 		await modelSelect.selectOption('gpt-4.1');
 		await expect(modelSelect).toHaveValue('gpt-4.1');
 
-		// Select the document
+		// Select the document and fill language
 		await page.locator('select').first().selectOption('doc_md_123');
+		await page.getByTestId('target-language-input').fill('Japanese');
 
 		// Click translate
-		await page.locator('button', { hasText: 'Start Translation' }).click();
+		const button = page.locator('button', { hasText: 'Start Translation' });
+		await expect(button).toBeEnabled({ timeout: 5000 });
+		await button.click({ force: true });
 
 		// Wait for result
 		await expect(page.getByRole('tab', { name: /japanese only/i })).toBeVisible({ timeout: 10000 });
@@ -605,6 +629,255 @@ test.describe('Model Selection', () => {
 		const capturedRequest = getRequest();
 		expect(capturedRequest?.model).toBe('gpt-4.1');
 		expect(capturedRequest?.reasoning_effort).toBeUndefined();
+	});
+});
+
+test.describe('Target Language Input', () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/');
+		await clearAllStorage(page);
+	});
+
+	test('shows target language input field', async ({ page }) => {
+		await page.goto('/translate');
+
+		const languageInput = page.getByTestId('target-language-input');
+		await expect(languageInput).toBeVisible();
+	});
+
+	test('translate button is disabled when language is empty', async ({ page }) => {
+		// Pre-populate IndexedDB with a markdown document
+		await addDocumentToIndexedDB(page, {
+			id: 'doc_md_123',
+			name: 'test-book.md',
+			type: 'markdown',
+			content: '# Test Book',
+			size: 11,
+			uploadedAt: new Date().toISOString(),
+			phase: 'uploaded'
+		});
+
+		await page.goto('/translate');
+
+		// Select a document
+		const select = page.locator('select').first();
+		await select.selectOption('doc_md_123');
+
+		// Language input should be empty
+		const languageInput = page.getByTestId('target-language-input');
+		await expect(languageInput).toHaveValue('');
+
+		// Button should be disabled
+		const button = page.locator('button', { hasText: 'Start Translation' });
+		await expect(button).toBeDisabled();
+	});
+
+	test('translate button is enabled when language is filled', async ({ page }) => {
+		// Pre-populate IndexedDB with a markdown document
+		await addDocumentToIndexedDB(page, {
+			id: 'doc_md_123',
+			name: 'test-book.md',
+			type: 'markdown',
+			content: '# Test Book',
+			size: 11,
+			uploadedAt: new Date().toISOString(),
+			phase: 'uploaded'
+		});
+
+		await page.goto('/translate');
+
+		// Select a document
+		const select = page.locator('select').first();
+		await select.selectOption('doc_md_123');
+
+		// Fill in target language
+		const languageInput = page.getByTestId('target-language-input');
+		await languageInput.fill('German');
+
+		// Button should now be enabled
+		const button = page.locator('button', { hasText: 'Start Translation' });
+		await expect(button).toBeEnabled();
+	});
+
+	test('shows validation message when language is empty and field touched', async ({ page }) => {
+		await page.goto('/translate');
+
+		// Focus and blur the language input without entering a value
+		const languageInput = page.getByTestId('target-language-input');
+		await languageInput.focus();
+		await languageInput.blur();
+
+		// Should show validation message
+		await expect(page.getByText(/target language.*required/i)).toBeVisible();
+	});
+
+	test('shows language history dropdown when input has history', async ({ page }) => {
+		// Set up some language history in localStorage
+		await page.goto('/translate');
+		await page.evaluate(() => {
+			localStorage.setItem(
+				'translation-language-history',
+				JSON.stringify(['Japanese', 'business casual German', 'formal French'])
+			);
+		});
+
+		// Reload to pick up localStorage
+		await page.goto('/translate');
+
+		// Focus on language input to show dropdown
+		const languageInput = page.getByTestId('target-language-input');
+		await languageInput.focus();
+
+		// Should show history items
+		await expect(page.getByTestId('language-history-dropdown')).toBeVisible();
+		await expect(page.getByText('Japanese')).toBeVisible();
+		await expect(page.getByText('business casual German')).toBeVisible();
+	});
+
+	test('selecting from history populates input', async ({ page }) => {
+		// Set up language history
+		await page.goto('/translate');
+		await page.evaluate(() => {
+			localStorage.setItem(
+				'translation-language-history',
+				JSON.stringify(['Japanese', 'German'])
+			);
+		});
+
+		await page.goto('/translate');
+
+		// Focus input to show dropdown
+		const languageInput = page.getByTestId('target-language-input');
+		await languageInput.focus();
+
+		// Wait for dropdown to be visible
+		await expect(page.getByTestId('language-history-dropdown')).toBeVisible();
+
+		// Click the German history item
+		const germanItem = page.getByTestId('language-history-item').filter({ hasText: 'German' });
+		await expect(germanItem).toBeVisible();
+		await germanItem.click({ force: true });
+
+		// Input should now have the selected value
+		await expect(languageInput).toHaveValue('German');
+	});
+
+	test('stores language to history after successful translation', async ({ page }) => {
+		// Pre-populate IndexedDB with a markdown document
+		await addDocumentToIndexedDB(page, {
+			id: 'doc_md_123',
+			name: 'test-book.md',
+			type: 'markdown',
+			content: '# Test',
+			size: 6,
+			uploadedAt: new Date().toISOString(),
+			phase: 'uploaded'
+		});
+
+		// Set API key and mock OpenAI (jsonWrap for contextAware translation)
+		await setApiKey(page);
+		await mockOpenAICompletion(page, '# Test auf Deutsch', { jsonWrap: true });
+
+		await page.goto('/translate');
+
+		// Select document and fill language
+		await page.locator('select').first().selectOption('doc_md_123');
+		const languageInput = page.getByTestId('target-language-input');
+		await languageInput.fill('German');
+
+		// Wait for button to be enabled, then click
+		const translateButton = page.locator('button', { hasText: 'Start Translation' });
+		await expect(translateButton).toBeEnabled({ timeout: 5000 });
+		await translateButton.click({ force: true });
+
+		// Wait for translation to complete (button returns to enabled after completion)
+		await expect(page.getByRole('tab', { name: /german only/i })).toBeVisible({ timeout: 10000 });
+
+		// Check localStorage for the language history
+		const history = await page.evaluate(() => {
+			return JSON.parse(localStorage.getItem('translation-language-history') || '[]');
+		});
+
+		expect(history).toContain('German');
+	});
+
+	test('translated document uses language code in filename', async ({ page }) => {
+		// Pre-populate IndexedDB with a markdown document
+		await addDocumentToIndexedDB(page, {
+			id: 'doc_md_123',
+			name: 'test-book.md',
+			type: 'markdown',
+			content: '# Test',
+			size: 6,
+			uploadedAt: new Date().toISOString(),
+			phase: 'uploaded'
+		});
+
+		// Set API key and mock OpenAI (jsonWrap for contextAware translation)
+		await setApiKey(page);
+		await mockOpenAICompletion(page, '# Test auf Deutsch', { jsonWrap: true });
+
+		await page.goto('/translate');
+
+		// Select document and fill language
+		await page.locator('select').first().selectOption('doc_md_123');
+		const languageInput = page.getByTestId('target-language-input');
+		await languageInput.fill('German');
+
+		// Wait for button to be enabled, then click
+		const translateButton = page.locator('button', { hasText: 'Start Translation' });
+		await expect(translateButton).toBeEnabled({ timeout: 5000 });
+		await translateButton.click({ force: true });
+
+		// Wait for translation to complete
+		await expect(page.getByRole('tab', { name: /german only/i })).toBeVisible({ timeout: 10000 });
+
+		// Check IndexedDB for the new documents
+		const docs = await getAllDocumentsFromIndexedDB(page);
+
+		// Should have a document with -de.md suffix
+		const germanDoc = docs.find((d) => d.name.includes('-de.md'));
+		expect(germanDoc).toBeDefined();
+		expect(germanDoc!.name).toBe('test-book-de.md');
+	});
+
+	test('passes target language to translator API', async ({ page }) => {
+		const markdownContent = '# Test';
+
+		// Pre-populate IndexedDB with a markdown document
+		await addDocumentToIndexedDB(page, {
+			id: 'doc_md_123',
+			name: 'test-book.md',
+			type: 'markdown',
+			content: markdownContent,
+			size: markdownContent.length,
+			uploadedAt: new Date().toISOString(),
+			phase: 'uploaded'
+		});
+
+		// Set API key and mock OpenAI, capturing the request (jsonWrap for contextAware translation)
+		await setApiKey(page);
+		const getRequest = await mockOpenAICompletion(page, '# Test auf Deutsch', { jsonWrap: true });
+
+		await page.goto('/translate');
+
+		// Select document and fill language
+		await page.locator('select').first().selectOption('doc_md_123');
+		const languageInput = page.getByTestId('target-language-input');
+		await languageInput.fill('German');
+
+		// Wait for button to be enabled, then click
+		const translateButton = page.locator('button', { hasText: 'Start Translation' });
+		await expect(translateButton).toBeEnabled({ timeout: 5000 });
+		await translateButton.click({ force: true });
+
+		// Wait for result
+		await expect(page.getByRole('tab', { name: /german only/i })).toBeVisible({ timeout: 10000 });
+
+		// Verify the system prompt includes the target language
+		const capturedRequest = getRequest();
+		const systemMessage = capturedRequest?.messages?.find((m) => m.role === 'system');
+		expect(systemMessage?.content).toContain('German');
 	});
 });
 

--- a/web-app/tests/e2e/workflow.spec.ts
+++ b/web-app/tests/e2e/workflow.spec.ts
@@ -19,7 +19,7 @@ test.describe('One Step Translation Page', () => {
 		await expect(page.getByText('Translation Settings')).toBeVisible();
 
 		// Check start button exists
-		await expect(page.getByRole('button', { name: /start complete workflow/i })).toBeVisible();
+		await expect(page.getByRole('button', { name: /start one step translation/i })).toBeVisible();
 	});
 
 	test('navigation shows workflow link with separator', async ({ page }) => {
@@ -45,7 +45,7 @@ test.describe('One Step Translation Page', () => {
 	test('start button is disabled when no file is selected', async ({ page }) => {
 		await page.goto('/workflow');
 
-		const startButton = page.getByRole('button', { name: /start complete workflow/i });
+		const startButton = page.getByRole('button', { name: /start one step translation/i });
 		await expect(startButton).toBeDisabled();
 	});
 
@@ -193,7 +193,7 @@ test.describe('Workflow UI States', () => {
 		// For now, we just verify the initial state
 		await page.goto('/workflow');
 
-		const startButton = page.getByRole('button', { name: /start complete workflow/i });
+		const startButton = page.getByRole('button', { name: /start one step translation/i });
 
 		// Button text should be "Start One Step Translation" initially
 		await expect(startButton).toContainText('Start One Step Translation');
@@ -203,7 +203,7 @@ test.describe('Workflow UI States', () => {
 		await page.goto('/workflow');
 
 		// Check that the start button contains an SVG icon
-		const startButton = page.getByRole('button', { name: /start complete workflow/i });
+		const startButton = page.getByRole('button', { name: /start one step translation/i });
 		const icon = startButton.locator('svg');
 		await expect(icon).toBeVisible();
 	});
@@ -211,13 +211,62 @@ test.describe('Workflow UI States', () => {
 	test('step numbers are displayed for each section', async ({ page }) => {
 		await page.goto('/workflow');
 
-		// Check step number badges (1, 2, 3) - use specific class to find the rounded badges
+		// Check step number badges (1, 2, 3, 4) - use specific class to find the rounded badges
 		const stepBadges = page.locator('.rounded-full.bg-blue-100');
-		await expect(stepBadges).toHaveCount(3);
+		await expect(stepBadges).toHaveCount(4);
 
 		// Verify the badges contain the step numbers
 		await expect(stepBadges.nth(0)).toContainText('1');
 		await expect(stepBadges.nth(1)).toContainText('2');
 		await expect(stepBadges.nth(2)).toContainText('3');
+		await expect(stepBadges.nth(3)).toContainText('4');
+	});
+});
+
+test.describe('Target Language and Tone Input', () => {
+	test.beforeEach(async ({ page }) => {
+		await page.goto('/');
+		await clearAllStorage(page);
+	});
+
+	test('shows target language and tone input field with correct label', async ({ page }) => {
+		await page.goto('/workflow');
+
+		// Check for the "Target language and tone" section heading
+		await expect(page.getByRole('heading', { name: 'Target language and tone' })).toBeVisible();
+
+		// Check for the input field
+		const input = page.getByTestId('target-language-input');
+		await expect(input).toBeVisible();
+	});
+
+	test('start button is disabled when target language is empty', async ({ page }) => {
+		await page.goto('/workflow');
+
+		// Even with a file, button should be disabled without language
+		const startButton = page.getByRole('button', { name: /start one step translation/i });
+		await expect(startButton).toBeDisabled();
+	});
+
+	test('shows language history dropdown when input has history', async ({ page }) => {
+		// Pre-populate language history
+		await page.goto('/workflow');
+		await page.evaluate(() => {
+			localStorage.setItem('translation-language-history', JSON.stringify(['Spanish', 'German']));
+		});
+
+		await page.reload();
+
+		// Focus the input
+		const input = page.getByTestId('target-language-input');
+		await input.focus();
+
+		// History dropdown should appear
+		await expect(page.getByTestId('language-history-dropdown')).toBeVisible();
+
+		// History items should be visible (using buttons in the dropdown)
+		const dropdown = page.getByTestId('language-history-dropdown');
+		await expect(dropdown.getByRole('button', { name: 'Spanish' })).toBeVisible();
+		await expect(dropdown.getByRole('button', { name: 'German' })).toBeVisible();
 	});
 });

--- a/web-app/tests/unit/languageHistory.test.ts
+++ b/web-app/tests/unit/languageHistory.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// Mock localStorage before importing the module
+const localStorageMock = (() => {
+	let store: Record<string, string> = {};
+	return {
+		getItem: vi.fn((key: string) => store[key] ?? null),
+		setItem: vi.fn((key: string, value: string) => {
+			store[key] = value;
+		}),
+		removeItem: vi.fn((key: string) => {
+			delete store[key];
+		}),
+		clear: vi.fn(() => {
+			store = {};
+		}),
+		__getStore: () => store,
+		__reset: () => {
+			store = {};
+		}
+	};
+})();
+
+vi.stubGlobal('localStorage', localStorageMock);
+
+import {
+	getLanguageHistory,
+	addLanguageToHistory,
+	clearLanguageHistory,
+	LANGUAGE_HISTORY_KEY,
+	MAX_HISTORY_ITEMS
+} from '$lib/languageHistory';
+
+describe('Language History', () => {
+	beforeEach(() => {
+		localStorageMock.__reset();
+		localStorageMock.getItem.mockClear();
+		localStorageMock.setItem.mockClear();
+	});
+
+	describe('getLanguageHistory', () => {
+		it('should return empty array when no history exists', () => {
+			const history = getLanguageHistory();
+			expect(history).toEqual([]);
+		});
+
+		it('should load history from localStorage', () => {
+			localStorageMock.__getStore()[LANGUAGE_HISTORY_KEY] = JSON.stringify(['Japanese', 'German']);
+
+			const history = getLanguageHistory();
+
+			expect(history).toEqual(['Japanese', 'German']);
+			expect(localStorageMock.getItem).toHaveBeenCalledWith(LANGUAGE_HISTORY_KEY);
+		});
+
+		it('should return empty array if localStorage contains invalid JSON', () => {
+			localStorageMock.__getStore()[LANGUAGE_HISTORY_KEY] = 'not valid json';
+
+			const history = getLanguageHistory();
+
+			expect(history).toEqual([]);
+		});
+	});
+
+	describe('addLanguageToHistory', () => {
+		it('should store language to history', () => {
+			addLanguageToHistory('Japanese');
+
+			const history = getLanguageHistory();
+			expect(history).toContain('Japanese');
+		});
+
+		it('should persist to localStorage', () => {
+			addLanguageToHistory('German');
+
+			expect(localStorageMock.setItem).toHaveBeenCalledWith(
+				LANGUAGE_HISTORY_KEY,
+				expect.stringContaining('German')
+			);
+		});
+
+		it('should put most recent at top', () => {
+			addLanguageToHistory('Japanese');
+			addLanguageToHistory('German');
+			addLanguageToHistory('French');
+
+			const history = getLanguageHistory();
+
+			expect(history[0]).toBe('French');
+			expect(history[1]).toBe('German');
+			expect(history[2]).toBe('Japanese');
+		});
+
+		it('should not add duplicates', () => {
+			addLanguageToHistory('Japanese');
+			addLanguageToHistory('German');
+			addLanguageToHistory('Japanese');
+
+			const history = getLanguageHistory();
+
+			expect(history.filter(l => l === 'Japanese').length).toBe(1);
+		});
+
+		it('should move existing entry to top when added again', () => {
+			addLanguageToHistory('Japanese');
+			addLanguageToHistory('German');
+			addLanguageToHistory('French');
+			addLanguageToHistory('Japanese');
+
+			const history = getLanguageHistory();
+
+			expect(history[0]).toBe('Japanese');
+			expect(history.length).toBe(3);
+		});
+
+		it('should limit history to MAX_HISTORY_ITEMS items', () => {
+			// Add more than MAX_HISTORY_ITEMS languages
+			for (let i = 0; i < MAX_HISTORY_ITEMS + 5; i++) {
+				addLanguageToHistory(`Language ${i}`);
+			}
+
+			const history = getLanguageHistory();
+
+			expect(history.length).toBe(MAX_HISTORY_ITEMS);
+		});
+
+		it('should remove oldest items when exceeding limit', () => {
+			for (let i = 0; i < MAX_HISTORY_ITEMS + 2; i++) {
+				addLanguageToHistory(`Language ${i}`);
+			}
+
+			const history = getLanguageHistory();
+
+			// Most recent should be at top
+			expect(history[0]).toBe(`Language ${MAX_HISTORY_ITEMS + 1}`);
+			// Oldest items (Language 0, Language 1) should be removed
+			expect(history).not.toContain('Language 0');
+			expect(history).not.toContain('Language 1');
+		});
+
+		it('should trim whitespace from language input', () => {
+			addLanguageToHistory('  Japanese  ');
+
+			const history = getLanguageHistory();
+
+			expect(history[0]).toBe('Japanese');
+		});
+
+		it('should not add empty strings', () => {
+			addLanguageToHistory('');
+			addLanguageToHistory('   ');
+
+			const history = getLanguageHistory();
+
+			expect(history.length).toBe(0);
+		});
+	});
+
+	describe('clearLanguageHistory', () => {
+		it('should clear all history', () => {
+			addLanguageToHistory('Japanese');
+			addLanguageToHistory('German');
+
+			clearLanguageHistory();
+
+			const history = getLanguageHistory();
+			expect(history).toEqual([]);
+		});
+
+		it('should remove from localStorage', () => {
+			addLanguageToHistory('Japanese');
+
+			clearLanguageHistory();
+
+			expect(localStorageMock.removeItem).toHaveBeenCalledWith(LANGUAGE_HISTORY_KEY);
+		});
+	});
+});

--- a/web-app/tests/unit/workflowEngine.test.ts
+++ b/web-app/tests/unit/workflowEngine.test.ts
@@ -55,7 +55,8 @@ describe('Workflow Engine', () => {
 		model: 'gpt-5-mini',
 		chunkSize: 4000,
 		reasoningEffort: 'medium',
-		contextAware: true
+		contextAware: true,
+		targetLanguage: 'Japanese'
 	};
 
 	beforeEach(() => {
@@ -205,7 +206,8 @@ describe('Workflow Engine', () => {
 				model: 'gpt-5.1',
 				chunkSize: 3000,
 				reasoningEffort: 'low',
-				contextAware: false
+				contextAware: false,
+				targetLanguage: 'German'
 			};
 
 			const options: WorkflowOptions = {


### PR DESCRIPTION
## Summary
- Add new Step 3 explaining OpenAI's prepaid billing requirement
- Update billing section with accurate prepaid billing information
- Fix troubleshooting to address "insufficient quota" errors
- Direct links to OpenAI billing/payment methods pages

## Test plan
- [x] All 242 unit tests pass
- [x] All 17 API key help e2e tests pass
- [x] Updated e2e test for more specific link selector

🤖 Generated with [Claude Code](https://claude.com/claude-code)